### PR TITLE
fix: use fixed key not to override note reference

### DIFF
--- a/src/components/Timeline/TimelineStandard.tsx
+++ b/src/components/Timeline/TimelineStandard.tsx
@@ -16,8 +16,8 @@ const TimelineStandard: React.FC<TimelineStandardProps> = ({
 }) => {
   return (
     <div className={classNames('sm:px-6 mb-20 max-w-xl', className)}>
-      {notes.map(({ ...note }, index) => (
-        <div key={index} className="mb-8 sm:mb-10">
+      {notes.map(({ ...note }, _) => (
+        <div key={note.id} className="mb-8 sm:mb-10">
           <NoteItem note={note} onToggleFollow={onToggleFollow} />
         </div>
       ))}


### PR DESCRIPTION
* keyに対して中身のコンテンツが入れ替われないようにする
* subscribeでnotesが更新されると、参照していたnoteも変わってしまう
* 例えば、表示中のノートのJSONが入れ替わったりする